### PR TITLE
Release 0.3.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,10 +19,10 @@ jobs:
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-      - name: Install .NET 6 SDK
+      - name: Install .NET 10 SDK
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '6.0.201'
+          dotnet-version: '10.x'
 
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - name: Checkout Repository

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v2
       with:
-        dotnet-version: 6.0.x
+        dotnet-version: 10.x
     - name: Restore dependencies
       run: dotnet restore
     - name: Build

--- a/.gitignore
+++ b/.gitignore
@@ -477,3 +477,6 @@ $RECYCLE.BIN/
 *.lnk
 
 .env
+
+# Test results
+*.trx

--- a/src/OneDriveCreatedAtOffsetProperty.cs
+++ b/src/OneDriveCreatedAtOffsetProperty.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Graph;
+using Microsoft.Graph.Models;
+using OwlCore.Storage;
+
+namespace OwlCore.Storage.OneDrive;
+
+/// <summary>
+/// A modifiable storage property for the creation timestamp of a OneDrive item with offset.
+/// </summary>
+public class OneDriveCreatedAtOffsetProperty : SimpleModifiableStorageProperty<DateTimeOffset?>, IModifiableCreatedAtOffsetProperty
+{
+    /// <summary>
+    /// Creates a new instance of <see cref="OneDriveCreatedAtOffsetProperty"/>.
+    /// </summary>
+    /// <param name="owner">The owning storable item.</param>
+    /// <param name="client">The Graph service client.</param>
+    /// <param name="itemId">The ID of the item.</param>
+    public OneDriveCreatedAtOffsetProperty(IStorable owner, GraphServiceClient client, string itemId)
+        : base(
+            id: owner.Id + "/" + nameof(ICreatedAtOffset.CreatedAtOffset),
+            name: nameof(ICreatedAtOffset.CreatedAtOffset),
+            asyncGetter: async ct =>
+            {
+                var drive = await client.Me.Drive.GetAsync(cancellationToken: ct);
+                var item = await client.Drives[drive!.Id].Items[itemId].GetAsync(cancellationToken: ct);
+                return item?.CreatedDateTime;
+            },
+            asyncSetter: async (val, ct) =>
+            {
+                var drive = await client.Me.Drive.GetAsync(cancellationToken: ct);
+                var updateItem = new DriveItem
+                {
+                    FileSystemInfo = new FileSystemInfo
+                    {
+                        CreatedDateTime = val
+                    }
+                };
+                await client.Drives[drive!.Id].Items[itemId].PatchAsync(updateItem, cancellationToken: ct);
+            })
+    {
+    }
+}

--- a/src/OneDriveCreatedAtProperty.cs
+++ b/src/OneDriveCreatedAtProperty.cs
@@ -1,0 +1,48 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Graph;
+using Microsoft.Graph.Models;
+using OwlCore.Storage;
+
+namespace OwlCore.Storage.OneDrive;
+
+/// <summary>
+/// A modifiable storage property for the creation timestamp of a OneDrive item.
+/// </summary>
+public class OneDriveCreatedAtProperty : SimpleModifiableStorageProperty<DateTime?>, IModifiableCreatedAtProperty
+{
+    /// <summary>
+    /// Creates a new instance of <see cref="OneDriveCreatedAtProperty"/>.
+    /// </summary>
+    /// <param name="owner">The owning storable item.</param>
+    /// <param name="client">The Graph service client.</param>
+    /// <param name="itemId">The ID of the item.</param>
+    public OneDriveCreatedAtProperty(IStorable owner, GraphServiceClient client, string itemId)
+        : base(
+            id: owner.Id + "/" + nameof(ICreatedAt.CreatedAt),
+            name: nameof(ICreatedAt.CreatedAt),
+            asyncGetter: async ct =>
+            {
+                var drive = await client.Me.Drive.GetAsync(cancellationToken: ct);
+                var item = await client.Drives[drive!.Id].Items[itemId].GetAsync(cancellationToken: ct);
+                return item?.CreatedDateTime?.LocalDateTime;
+            },
+            asyncSetter: async (val, ct) =>
+            {
+                // CreatedDateTime is read-only on BaseItem but can be set via FileSystemInfo for preservation purposes during migration
+                // However, the interface expects us to try and set it.
+                // Graph API prioritizes FileSystemInfo for setting timestamps.
+                var drive = await client.Me.Drive.GetAsync(cancellationToken: ct);
+                var updateItem = new DriveItem
+                {
+                    FileSystemInfo = new FileSystemInfo
+                    {
+                        CreatedDateTime = val.HasValue ? new DateTimeOffset(val.Value) : null
+                    }
+                };
+                await client.Drives[drive!.Id].Items[itemId].PatchAsync(updateItem, cancellationToken: ct);
+            })
+    {
+    }
+}

--- a/src/OneDriveFile.cs
+++ b/src/OneDriveFile.cs
@@ -1,5 +1,6 @@
 using Microsoft.Graph;
 using Microsoft.Graph.Models;
+using System;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
@@ -9,9 +10,15 @@ namespace OwlCore.Storage.OneDrive;
 /// <summary>
 /// A file implementation that interacts with a file in OneDrive.
 /// </summary>
-public class OneDriveFile : IFile, IChildFile
+public class OneDriveFile : IFile, IChildFile, ICreatedAtOffset, ILastAccessedAtOffset, ILastModifiedAtOffset
 {
     private readonly GraphServiceClient _graphClient;
+    private OneDriveCreatedAtProperty? _createdAt;
+    private OneDriveCreatedAtOffsetProperty? _createdAtOffset;
+    private OneDriveLastAccessedAtProperty? _lastAccessedAt;
+    private OneDriveLastAccessedAtOffsetProperty? _lastAccessedAtOffset;
+    private OneDriveLastModifiedAtProperty? _lastModifiedAt;
+    private OneDriveLastModifiedAtOffsetProperty? _lastModifiedAtOffset;
 
     /// <summary>
     /// Creates a new instance of <see cref="OneDriveFile"/>.
@@ -28,26 +35,47 @@ public class OneDriveFile : IFile, IChildFile
     public DriveItem DriveItem { get; }
 
     /// <inheritdoc />
-    public string Id => DriveItem.Id;
+    public string Id => DriveItem.Id!;
 
     /// <inheritdoc />
-    public string Name => DriveItem.Name;
+    public string Name => DriveItem.Name!;
+
+    /// <inheritdoc />
+    public ICreatedAtProperty CreatedAt => _createdAt ??= new OneDriveCreatedAtProperty(this, _graphClient, DriveItem.Id!);
+
+    /// <inheritdoc />
+    public ICreatedAtOffsetProperty CreatedAtOffset => _createdAtOffset ??= new OneDriveCreatedAtOffsetProperty(this, _graphClient, DriveItem.Id!);
+
+    /// <inheritdoc />
+    public ILastAccessedAtProperty LastAccessedAt => _lastAccessedAt ??= new OneDriveLastAccessedAtProperty(this, _graphClient, DriveItem.Id!);
+
+    /// <inheritdoc />
+    public ILastAccessedAtOffsetProperty LastAccessedAtOffset => _lastAccessedAtOffset ??= new OneDriveLastAccessedAtOffsetProperty(this, _graphClient, DriveItem.Id!);
+
+    /// <inheritdoc />
+    public ILastModifiedAtProperty LastModifiedAt => _lastModifiedAt ??= new OneDriveLastModifiedAtProperty(this, _graphClient, DriveItem.Id!);
+
+    /// <inheritdoc />
+    public ILastModifiedAtOffsetProperty LastModifiedAtOffset => _lastModifiedAtOffset ??= new OneDriveLastModifiedAtOffsetProperty(this, _graphClient, DriveItem.Id!);
 
     /// <inheritdoc />
     public virtual async Task<IFolder?> GetParentAsync(CancellationToken cancellationToken = default)
     {
         var drive = await _graphClient.Me.Drive.GetAsync(cancellationToken: cancellationToken);
-        var parent = await _graphClient.Drives[drive.Id].Items[DriveItem.ParentReference.Id].GetAsync(cancellationToken: cancellationToken);
+        var parent = await _graphClient.Drives[drive!.Id].Items[DriveItem.ParentReference!.Id].GetAsync(cancellationToken: cancellationToken);
 
-        return new OneDriveFolder(_graphClient, parent);
+        return new OneDriveFolder(_graphClient, parent!);
     }
 
     /// <inheritdoc />
     public async Task<Stream> OpenStreamAsync(FileAccess accessMode = FileAccess.Read, CancellationToken cancellationToken = default)
     {
-        var drive = await _graphClient.Me.Drive.GetAsync(cancellationToken: cancellationToken);
-        var result = await _graphClient.Drives[drive.Id].Items[Id].Content.GetAsync(cancellationToken: cancellationToken);
+        if (accessMode == 0 || (int)accessMode > 3)
+            throw new ArgumentOutOfRangeException(nameof(accessMode));
 
-        return result;
+        var drive = await _graphClient.Me.Drive.GetAsync(cancellationToken: cancellationToken);
+        var result = await _graphClient.Drives[drive!.Id].Items[Id].Content.GetAsync(cancellationToken: cancellationToken);
+
+        return result!;
     }
 }

--- a/src/OneDriveFolder.cs
+++ b/src/OneDriveFolder.cs
@@ -1,19 +1,26 @@
-﻿using Microsoft.Graph;
+using Microsoft.Graph;
 using Microsoft.Graph.Models;
 using System.Collections.Generic;
 using System.IO;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
+using System;
 
 namespace OwlCore.Storage.OneDrive;
 
 /// <summary>
 /// A folder implementation that interacts with a folder in OneDrive.
 /// </summary>
-public class OneDriveFolder : IChildFolder, IGetItem, IGetItemRecursive, IGetRoot
+public class OneDriveFolder : IChildFolder, IGetItem, IGetItemRecursive, IGetRoot, ICreatedAtOffset, ILastAccessedAtOffset, ILastModifiedAtOffset
 {
     private readonly GraphServiceClient _graphClient;
+    private OneDriveCreatedAtProperty? _createdAt;
+    private OneDriveCreatedAtOffsetProperty? _createdAtOffset;
+    private OneDriveLastAccessedAtProperty? _lastAccessedAt;
+    private OneDriveLastAccessedAtOffsetProperty? _lastAccessedAtOffset;
+    private OneDriveLastModifiedAtProperty? _lastModifiedAt;
+    private OneDriveLastModifiedAtOffsetProperty? _lastModifiedAtOffset;
 
     /// <summary>
     /// Creates a new instance of <see cref="OneDriveFolder"/>.
@@ -25,10 +32,10 @@ public class OneDriveFolder : IChildFolder, IGetItem, IGetItemRecursive, IGetRoo
     }
 
     /// <inheritdoc />
-    public string Id => DriveItem.Id;
+    public string Id => DriveItem.Id!;
 
     /// <inheritdoc />
-    public string Name => DriveItem.Name;
+    public string Name => DriveItem.Name!;
 
     /// <summary>
     /// The graph item that was provided as the backing implementation for this file.
@@ -36,14 +43,35 @@ public class OneDriveFolder : IChildFolder, IGetItem, IGetItemRecursive, IGetRoo
     public DriveItem DriveItem { get; }
 
     /// <inheritdoc />
+    public ICreatedAtProperty CreatedAt => _createdAt ??= new OneDriveCreatedAtProperty(this, _graphClient, DriveItem.Id!);
+
+    /// <inheritdoc />
+    public ICreatedAtOffsetProperty CreatedAtOffset => _createdAtOffset ??= new OneDriveCreatedAtOffsetProperty(this, _graphClient, DriveItem.Id!);
+
+    /// <inheritdoc />
+    public ILastAccessedAtProperty LastAccessedAt => _lastAccessedAt ??= new OneDriveLastAccessedAtProperty(this, _graphClient, DriveItem.Id!);
+
+    /// <inheritdoc />
+    public ILastAccessedAtOffsetProperty LastAccessedAtOffset => _lastAccessedAtOffset ??= new OneDriveLastAccessedAtOffsetProperty(this, _graphClient, DriveItem.Id!);
+
+    /// <inheritdoc />
+    public ILastModifiedAtProperty LastModifiedAt => _lastModifiedAt ??= new OneDriveLastModifiedAtProperty(this, _graphClient, DriveItem.Id!);
+
+    /// <inheritdoc />
+    public ILastModifiedAtOffsetProperty LastModifiedAtOffset => _lastModifiedAtOffset ??= new OneDriveLastModifiedAtOffsetProperty(this, _graphClient, DriveItem.Id!);
+
+    /// <inheritdoc />
     public virtual async IAsyncEnumerable<IStorableChild> GetItemsAsync(StorableType type = StorableType.All, [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
 
-        var drive = await _graphClient.Me.Drive.GetAsync(cancellationToken: cancellationToken);
-        var result = await _graphClient.Drives[drive.Id].Items[Id].Children.GetAsync(cancellationToken: cancellationToken);
+        if (type == StorableType.None)
+            throw new ArgumentOutOfRangeException(nameof(type));
 
-        foreach (var item in result.Value)
+        var drive = await _graphClient.Me.Drive.GetAsync(cancellationToken: cancellationToken);
+        var result = await _graphClient.Drives[drive!.Id].Items[Id].Children.GetAsync(cancellationToken: cancellationToken);
+
+        foreach (var item in result!.Value!)
         {
             cancellationToken.ThrowIfCancellationRequested();
 
@@ -64,7 +92,7 @@ public class OneDriveFolder : IChildFolder, IGetItem, IGetItemRecursive, IGetRoo
         try
         {
             var drive = await _graphClient.Me.Drive.GetAsync(cancellationToken: cancellationToken);
-            var driveItem = await _graphClient.Drives[drive.Id].Items[id].GetAsync(cancellationToken: cancellationToken);
+            var driveItem = await _graphClient.Drives[drive!.Id].Items[id].GetAsync(cancellationToken: cancellationToken);
 
             if (driveItem?.Folder is not null)
                 return new OneDriveFolder(_graphClient, driveItem);
@@ -87,9 +115,9 @@ public class OneDriveFolder : IChildFolder, IGetItem, IGetItemRecursive, IGetRoo
             return null;
 
         var drive = await _graphClient.Me.Drive.GetAsync(cancellationToken: cancellationToken);
-        var parentDriveItem = await _graphClient.Drives[drive.Id].Items[DriveItem.ParentReference.Id].GetAsync(cancellationToken: cancellationToken);
+        var parentDriveItem = await _graphClient.Drives[drive!.Id].Items[DriveItem.ParentReference.Id].GetAsync(cancellationToken: cancellationToken);
 
-        return new OneDriveFolder(_graphClient, parentDriveItem);
+        return new OneDriveFolder(_graphClient, parentDriveItem!);
     }
 
     /// <inheritdoc />
@@ -99,8 +127,8 @@ public class OneDriveFolder : IChildFolder, IGetItem, IGetItemRecursive, IGetRoo
             return null;
 
         var drive = await _graphClient.Me.Drive.GetAsync(cancellationToken: cancellationToken);
-        var rootDriveItem = await _graphClient.Drives[drive.Id].Root.GetAsync(cancellationToken: cancellationToken);
+        var rootDriveItem = await _graphClient.Drives[drive!.Id].Root.GetAsync(cancellationToken: cancellationToken);
 
-        return new OneDriveFolder(_graphClient, rootDriveItem);
+        return new OneDriveFolder(_graphClient, rootDriveItem!);
     }
 }

--- a/src/OneDriveLastAccessedAtOffsetProperty.cs
+++ b/src/OneDriveLastAccessedAtOffsetProperty.cs
@@ -1,0 +1,33 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Graph;
+using Microsoft.Graph.Models;
+using OwlCore.Storage;
+
+namespace OwlCore.Storage.OneDrive;
+
+/// <summary>
+/// A read-only storage property for the last accessed timestamp of a OneDrive item.
+/// </summary>
+public class OneDriveLastAccessedAtOffsetProperty : SimpleStorageProperty<DateTimeOffset?>, ILastAccessedAtOffsetProperty
+{
+    /// <summary>
+    /// Creates a new instance of <see cref="OneDriveLastAccessedAtOffsetProperty"/>.
+    /// </summary>
+    /// <param name="owner">The owning storable item.</param>
+    /// <param name="client">The Graph service client.</param>
+    /// <param name="itemId">The ID of the item.</param>
+    public OneDriveLastAccessedAtOffsetProperty(IStorable owner, GraphServiceClient client, string itemId)
+        : base(
+            id: owner.Id + "/" + nameof(ILastAccessedAtOffset.LastAccessedAtOffset),
+            name: nameof(ILastAccessedAtOffset.LastAccessedAtOffset),
+            asyncGetter: async ct =>
+            {
+                var drive = await client.Me.Drive.GetAsync(cancellationToken: ct);
+                var item = await client.Drives[drive!.Id].Items[itemId].GetAsync(cancellationToken: ct);
+                return item?.FileSystemInfo?.LastAccessedDateTime;
+            })
+    {
+    }
+}

--- a/src/OneDriveLastAccessedAtProperty.cs
+++ b/src/OneDriveLastAccessedAtProperty.cs
@@ -1,0 +1,33 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Graph;
+using Microsoft.Graph.Models;
+using OwlCore.Storage;
+
+namespace OwlCore.Storage.OneDrive;
+
+/// <summary>
+/// A read-only storage property for the last accessed timestamp of a OneDrive item.
+/// </summary>
+public class OneDriveLastAccessedAtProperty : SimpleStorageProperty<DateTime?>, ILastAccessedAtProperty
+{
+    /// <summary>
+    /// Creates a new instance of <see cref="OneDriveLastAccessedAtProperty"/>.
+    /// </summary>
+    /// <param name="owner">The owning storable item.</param>
+    /// <param name="client">The Graph service client.</param>
+    /// <param name="itemId">The ID of the item.</param>
+    public OneDriveLastAccessedAtProperty(IStorable owner, GraphServiceClient client, string itemId)
+        : base(
+            id: owner.Id + "/" + nameof(ILastAccessedAt.LastAccessedAt),
+            name: nameof(ILastAccessedAt.LastAccessedAt),
+            asyncGetter: async ct =>
+            {
+                var drive = await client.Me.Drive.GetAsync(cancellationToken: ct);
+                var item = await client.Drives[drive!.Id].Items[itemId].GetAsync(cancellationToken: ct);
+                return item?.FileSystemInfo?.LastAccessedDateTime?.LocalDateTime;
+            })
+    {
+    }
+}

--- a/src/OneDriveLastModifiedAtOffsetProperty.cs
+++ b/src/OneDriveLastModifiedAtOffsetProperty.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Graph;
+using Microsoft.Graph.Models;
+using OwlCore.Storage;
+
+namespace OwlCore.Storage.OneDrive;
+
+/// <summary>
+/// A modifiable storage property for the last modified timestamp of a OneDrive item with offset.
+/// </summary>
+public class OneDriveLastModifiedAtOffsetProperty : SimpleModifiableStorageProperty<DateTimeOffset?>, IModifiableLastModifiedAtOffsetProperty
+{
+    /// <summary>
+    /// Creates a new instance of <see cref="OneDriveLastModifiedAtOffsetProperty"/>.
+    /// </summary>
+    /// <param name="owner">The owning storable item.</param>
+    /// <param name="client">The Graph service client.</param>
+    /// <param name="itemId">The ID of the item.</param>
+    public OneDriveLastModifiedAtOffsetProperty(IStorable owner, GraphServiceClient client, string itemId)
+        : base(
+            id: owner.Id + "/" + nameof(ILastModifiedAtOffset.LastModifiedAtOffset),
+            name: nameof(ILastModifiedAtOffset.LastModifiedAtOffset),
+            asyncGetter: async ct =>
+            {
+                var drive = await client.Me.Drive.GetAsync(cancellationToken: ct);
+                var item = await client.Drives[drive!.Id].Items[itemId].GetAsync(cancellationToken: ct);
+                return item?.LastModifiedDateTime;
+            },
+            asyncSetter: async (val, ct) =>
+            {
+                var drive = await client.Me.Drive.GetAsync(cancellationToken: ct);
+                var updateItem = new DriveItem
+                {
+                    FileSystemInfo = new FileSystemInfo
+                    {
+                        LastModifiedDateTime = val
+                    }
+                };
+                await client.Drives[drive!.Id].Items[itemId].PatchAsync(updateItem, cancellationToken: ct);
+            })
+    {
+    }
+}

--- a/src/OneDriveLastModifiedAtProperty.cs
+++ b/src/OneDriveLastModifiedAtProperty.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Graph;
+using Microsoft.Graph.Models;
+using OwlCore.Storage;
+
+namespace OwlCore.Storage.OneDrive;
+
+/// <summary>
+/// A modifiable storage property for the last modified timestamp of a OneDrive item.
+/// </summary>
+public class OneDriveLastModifiedAtProperty : SimpleModifiableStorageProperty<DateTime?>, IModifiableLastModifiedAtProperty
+{
+    /// <summary>
+    /// Creates a new instance of <see cref="OneDriveLastModifiedAtProperty"/>.
+    /// </summary>
+    /// <param name="owner">The owning storable item.</param>
+    /// <param name="client">The Graph service client.</param>
+    /// <param name="itemId">The ID of the item.</param>
+    public OneDriveLastModifiedAtProperty(IStorable owner, GraphServiceClient client, string itemId)
+        : base(
+            id: owner.Id + "/" + nameof(ILastModifiedAt.LastModifiedAt),
+            name: nameof(ILastModifiedAt.LastModifiedAt),
+            asyncGetter: async ct =>
+            {
+                var drive = await client.Me.Drive.GetAsync(cancellationToken: ct);
+                var item = await client.Drives[drive!.Id].Items[itemId].GetAsync(cancellationToken: ct);
+                return item?.LastModifiedDateTime?.LocalDateTime;
+            },
+            asyncSetter: async (val, ct) =>
+            {
+                var drive = await client.Me.Drive.GetAsync(cancellationToken: ct);
+                var updateItem = new DriveItem
+                {
+                    FileSystemInfo = new FileSystemInfo
+                    {
+                        LastModifiedDateTime = val.HasValue ? new DateTimeOffset(val.Value) : null
+                    }
+                };
+                await client.Drives[drive!.Id].Items[itemId].PatchAsync(updateItem, cancellationToken: ct);
+            })
+    {
+    }
+}

--- a/src/OwlCore.Storage.OneDrive.csproj
+++ b/src/OwlCore.Storage.OneDrive.csproj
@@ -1,6 +1,6 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net8.0;net9.0;net10.0</TargetFrameworks>
     <Nullable>enable</Nullable>
     <LangVersion>10.0</LangVersion>
     <WarningsAsErrors>nullable</WarningsAsErrors>
@@ -14,13 +14,27 @@
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
 
     <Author>Arlo Godfrey</Author>
-    <Version>0.2.1</Version>
+    <Version>0.3.0</Version>
     <Product>OwlCore</Product>
     <Description></Description>
     <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
     <PackageIcon>logo.png</PackageIcon>
     <PackageProjectUrl>https://github.com/Arlodotexe/OwlCore.Storage.OneDrive</PackageProjectUrl>
     <PackageReleaseNotes>
+--- 0.3.0 ---
+[New]
+OneDriveFile now implements ICreatedAtOffset, ILastAccessedAtOffset, and ILastModifiedAtOffset.
+OneDriveFolder now implements ICreatedAtOffset, ILastAccessedAtOffset, and ILastModifiedAtOffset.
+Added OneDriveCreatedAtProperty, OneDriveCreatedAtOffsetProperty, OneDriveLastAccessedAtProperty, OneDriveLastAccessedAtOffsetProperty, OneDriveLastModifiedAtProperty, OneDriveLastModifiedAtOffsetProperty — each backed by Microsoft Graph DriveItem timestamp fields.
+
+[Dependencies]
+Updated OwlCore.Storage to 0.15.0.
+Updated Microsoft.Graph to 5.103.0.
+Updated Microsoft.SourceLink.GitHub to 10.0.103.
+Updated System.Linq.Async to 7.0.0.
+Updated Microsoft.Bcl.AsyncInterfaces to 10.0.3.
+Added net9.0 and net10.0 target frameworks.
+
 --- 0.2.1 ---
 [Improvements]
 Added missing package release notes.
@@ -70,15 +84,16 @@ Initial release of OwlCore.Storage.OneDrive.
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Graph" Version="5.44.0" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
-    <PackageReference Include="OwlCore.Storage" Version="0.10.0" />
-    <PackageReference Include="System.Linq.Async" Version="6.0.1" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.3" Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net10.0'))" />
+    <PackageReference Include="Microsoft.Graph" Version="5.103.0" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.103" PrivateAssets="All" />
+    <PackageReference Include="OwlCore.Storage" Version="0.15.0" />
+    <PackageReference Include="PolySharp" Version="1.15.0" PrivateAssets="All" />
+    <PackageReference Include="System.Linq.Async" Version="7.0.0" Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net10.0'))" />
   </ItemGroup>
 
   <ItemGroup>
-    <None Update="logo.png">
+    <None Include="logo.png">
       <Pack>True</Pack>
       <PackagePath>\</PackagePath>
     </None>

--- a/tests/OneDriveFileTests.cs
+++ b/tests/OneDriveFileTests.cs
@@ -1,0 +1,120 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Graph;
+using Microsoft.Graph.Models;
+using Microsoft.Kiota.Abstractions.Authentication;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using OwlCore.Storage.CommonTests;
+
+namespace OwlCore.Storage.OneDrive.Tests;
+
+[TestClass]
+public class OneDriveFileTests : CommonIFileTests
+{
+    private GraphServiceClient? _graphClient;
+
+    public override bool SupportsWriting => false;
+
+    // OneDrive does not reliably populate LastAccessedAt
+    public override PropertyValueAvailability LastAccessedAtAvailability => PropertyValueAvailability.Maybe;
+
+    // OneDrive updates are eventual, not immediate
+    public override PropertyUpdateBehavior LastModifiedAtUpdateBehavior => PropertyUpdateBehavior.Eventual;
+    public override PropertyUpdateBehavior LastAccessedAtUpdateBehavior => PropertyUpdateBehavior.Never;
+
+    public async Task<GraphServiceClient> GetGraphClientAsync()
+    {
+        if (_graphClient is not null)
+            return _graphClient;
+
+        var token = OneDriveTestConfig.GetAccessToken();
+
+        if (string.IsNullOrWhiteSpace(token))
+        {
+            Assert.Inconclusive("Token not found. Set the 'OC_ONEDRIVE_TOKEN' environment variable or user secret.");
+        }
+
+        var accessTokenProvider = new TestAccessTokenProvider(token);
+        var authProvider = new BaseBearerTokenAuthenticationProvider(accessTokenProvider);
+        _graphClient = new GraphServiceClient(authProvider);
+
+        return _graphClient;
+    }
+
+    public override async Task<IFile> CreateFileAsync()
+    {
+        var client = await GetGraphClientAsync();
+        
+        // Use a specific test root folder
+        var testRootName = "OwlCore_Storage_Tests";
+        
+        DriveItem rootFolder;
+        try
+        {
+            var drive = await client.Me.Drive.GetAsync();
+            var children = await client.Drives[drive.Id].Items["root"].Children.GetAsync();
+            
+             DriveItem? existing = null;
+             if (children?.Value != null)
+             {
+                 foreach(var item in children.Value)
+                 {
+                    if (item.Name == testRootName) 
+                    {
+                        existing = item;
+                        break;
+                    }
+                 }
+             }
+
+             if (existing != null)
+                 rootFolder = existing;
+             else
+             {
+                 var newRoot = new DriveItem
+                 {
+                     Name = testRootName,
+                     Folder = new Folder(),
+                     AdditionalData = new global::System.Collections.Generic.Dictionary<string, object>
+                     {
+                         { "@microsoft.graph.conflictBehavior", "replace" }
+                     }
+                 };
+                 rootFolder = await client.Drives[drive.Id].Items["root"].Children.PostAsync(newRoot);
+             }
+
+             // Create a random file
+             var uniqueName = Guid.NewGuid().ToString() + ".txt";
+             
+             var fileToCreate = new DriveItem
+             {
+                 Name = uniqueName,
+                 File = new Microsoft.Graph.Models.FileObject(),
+                 AdditionalData = new global::System.Collections.Generic.Dictionary<string, object>
+                 {
+                     { "@microsoft.graph.conflictBehavior", "fail" }
+                 }
+             };
+             
+             var createdItem = await client.Drives[drive.Id].Items[rootFolder.Id].Children.PostAsync(fileToCreate);
+
+             // Add content to the file
+             using var contentStream = new MemoryStream(global::System.Text.Encoding.UTF8.GetBytes("Hello World"));
+             await client.Drives[drive.Id].Items[createdItem.Id].Content.PutAsync(contentStream);
+
+             // Return the file wrapper
+             return new OneDriveFile(client, createdItem);
+        }
+        catch (Exception ex)
+        {
+             throw new InvalidOperationException($"Could not setup test file: {ex.Message}", ex);
+        }
+    }
+
+    // OneDrive doesn't support setting timestamps at creation via the Graph API
+    public override Task<IFile?> CreateFileWithCreatedAtAsync(DateTime createdAt) => Task.FromResult<IFile?>(null);
+    public override Task<IFile?> CreateFileWithLastModifiedAtAsync(DateTime lastModifiedAt) => Task.FromResult<IFile?>(null);
+    public override Task<IFile?> CreateFileWithLastAccessedAtAsync(DateTime lastAccessedAt) => Task.FromResult<IFile?>(null);
+}

--- a/tests/OneDriveFolderTests.cs
+++ b/tests/OneDriveFolderTests.cs
@@ -1,0 +1,161 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Graph;
+using Microsoft.Graph.Models;
+using Microsoft.Kiota.Abstractions.Authentication;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using OwlCore.Storage.CommonTests;
+
+namespace OwlCore.Storage.OneDrive.Tests;
+
+[TestClass]
+public class OneDriveFolderTests : CommonIFolderTests
+{
+    private GraphServiceClient? _graphClient;
+
+    // OneDrive does not reliably populate LastAccessedAt, and does not provide any user-level control over it.
+    public override PropertyValueAvailability LastAccessedAtAvailability => PropertyValueAvailability.Maybe;
+
+    // OneDrive updates are eventual, not immediate
+    public override PropertyUpdateBehavior LastModifiedAtUpdateBehavior => PropertyUpdateBehavior.Eventual;
+    public override PropertyUpdateBehavior LastAccessedAtUpdateBehavior => PropertyUpdateBehavior.Eventual;
+    public override PropertyUpdateBehavior CreatedAtUpdateBehavior => PropertyUpdateBehavior.Never;
+
+    public async Task<GraphServiceClient> GetGraphClientAsync()
+    {
+        if (_graphClient is not null)
+            return _graphClient;
+
+        var token = OneDriveTestConfig.GetAccessToken();
+
+        if (string.IsNullOrWhiteSpace(token))
+        {
+            Assert.Inconclusive("Token not found. Set the 'OC_ONEDRIVE_TOKEN' environment variable or user secret.");
+        }
+
+        var accessTokenProvider = new TestAccessTokenProvider(token);
+        var authProvider = new BaseBearerTokenAuthenticationProvider(accessTokenProvider);
+        _graphClient = new GraphServiceClient(authProvider);
+
+        // Verify connectivity
+        try 
+        {
+             await _graphClient.Me.GetAsync();
+        }
+        catch (Exception ex)
+        {
+            Assert.Inconclusive($"Failed to connect to Graph API: {ex.Message}");
+        }
+
+        return _graphClient;
+    }
+
+    public override async Task<IFolder> CreateFolderAsync()
+    {
+        var client = await GetGraphClientAsync();
+        
+        var testRootName = "OwlCore_Storage_Tests";
+        
+        // Ensure test root exists
+        DriveItem rootFolder;
+        try
+        {
+            var drive = await client.Me.Drive.GetAsync();
+            var children = await client.Drives[drive.Id].Items["root"].Children.GetAsync();
+             
+             DriveItem? existing = null;
+             if (children?.Value != null)
+             {
+                 foreach(var item in children.Value)
+                 {
+                    if (item.Name == testRootName) 
+                    {
+                        existing = item;
+                        break;
+                    }
+                 }
+             }
+
+             if (existing != null)
+                 rootFolder = existing;
+             else
+             {
+                 var newRoot = new DriveItem
+                 {
+                     Name = testRootName,
+                     Folder = new Folder(),
+                     AdditionalData = new global::System.Collections.Generic.Dictionary<string, object>
+                     {
+                         { "@microsoft.graph.conflictBehavior", "replace" }
+                     }
+                 };
+                 rootFolder = await client.Drives[drive.Id].Items["root"].Children.PostAsync(newRoot);
+             }
+        }
+        catch (Exception ex)
+        {
+             throw new InvalidOperationException($"Could not setup test root: {ex.Message}", ex);
+        }
+
+        // Create a unique folder for THIS test instance
+        var uniqueName = Guid.NewGuid().ToString();
+        var driveRef = await client.Me.Drive.GetAsync();
+        
+        var folderToCreate = new DriveItem
+        {
+            Name = uniqueName,
+            Folder = new Folder(),
+             AdditionalData = new global::System.Collections.Generic.Dictionary<string, object>
+             {
+                 { "@microsoft.graph.conflictBehavior", "fail" }
+             }
+        };
+
+        var createdItem = await client.Drives[driveRef.Id].Items[rootFolder.Id].Children.PostAsync(folderToCreate);
+
+        return new OneDriveFolder(client, createdItem);
+    }
+
+    public override async Task<IFolder> CreateFolderWithItems(int fileCount, int folderCount)
+    {
+        var folder = (OneDriveFolder)await CreateFolderAsync();
+        var client = await GetGraphClientAsync();
+        var drive = await client.Me.Drive.GetAsync();
+
+        for (int i = 0; i < fileCount; i++)
+        {
+             var fileToCreate = new DriveItem
+             {
+                 Name = $"File_{i}.txt",
+                 File = new Microsoft.Graph.Models.FileObject(),
+                 AdditionalData = new global::System.Collections.Generic.Dictionary<string, object>
+                 {
+                     { "@microsoft.graph.conflictBehavior", "fail" }
+                 }
+             };
+             await client.Drives[drive.Id].Items[folder.Id].Children.PostAsync(fileToCreate);
+        }
+
+        for (int i = 0; i < folderCount; i++)
+        {
+             var folderToCreate = new DriveItem
+             {
+                 Name = $"Folder_{i}",
+                 Folder = new Folder(),
+                 AdditionalData = new global::System.Collections.Generic.Dictionary<string, object>
+                 {
+                     { "@microsoft.graph.conflictBehavior", "fail" }
+                 }
+             };
+             await client.Drives[drive.Id].Items[folder.Id].Children.PostAsync(folderToCreate);
+        }
+
+        return folder;
+    }
+
+    public override Task<IFolder?> CreateFolderWithCreatedAtAsync(DateTime createdAt) => Task.FromResult<IFolder?>(null);
+    public override Task<IFolder?> CreateFolderWithLastModifiedAtAsync(DateTime lastModifiedAt) => Task.FromResult<IFolder?>(null);
+    public override Task<IFolder?> CreateFolderWithLastAccessedAtAsync(DateTime lastAccessedAt) => Task.FromResult<IFolder?>(null);
+}

--- a/tests/OneDriveTestConfig.cs
+++ b/tests/OneDriveTestConfig.cs
@@ -1,0 +1,21 @@
+using Microsoft.Extensions.Configuration;
+
+namespace OwlCore.Storage.OneDrive.Tests;
+
+public static class OneDriveTestConfig
+{
+    private static IConfigurationRoot? _config;
+
+    public static string GetAccessToken()
+    {
+        if (_config == null)
+        {
+            var builder = new ConfigurationBuilder()
+                .AddUserSecrets<OneDriveFolderTests>()
+                .AddEnvironmentVariables();
+            _config = builder.Build();
+        }
+
+        return _config["OC_ONEDRIVE_TOKEN"] ?? string.Empty;
+    }
+}

--- a/tests/OwlCore.Storage.OneDrive.Tests.csproj
+++ b/tests/OwlCore.Storage.OneDrive.Tests.csproj
@@ -1,0 +1,35 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+    <LangVersion>latest</LangVersion>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <UserSecretsId>93803446-9b65-4ba7-bd29-d9bf90282cae</UserSecretsId>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="10.0.3" />
+    
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="Microsoft.TestPlatform" Version="17.12.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.7.3" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.7.3" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Microsoft.VisualStudio.TestTools.UnitTesting" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="OwlCore.Storage" Version="0.15.0" />
+    <PackageReference Include="OwlCore.Storage.CommonTests" Version="0.6.2" />
+    <ProjectReference Include="..\src\OwlCore.Storage.OneDrive.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/TestAccessTokenProvider.cs
+++ b/tests/TestAccessTokenProvider.cs
@@ -1,0 +1,22 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Kiota.Abstractions.Authentication;
+
+namespace OwlCore.Storage.OneDrive.Tests;
+
+public class TestAccessTokenProvider : IAccessTokenProvider
+{
+    private readonly string _token;
+
+    public TestAccessTokenProvider(string token)
+    {
+        _token = token;
+    }
+
+    public Task<string> GetAuthorizationTokenAsync(Uri uri, Dictionary<string, object>? additionalAuthenticationContext = default, CancellationToken cancellationToken = default) 
+        => Task.FromResult(_token);
+
+    public AllowedHostsValidator AllowedHostsValidator => new AllowedHostsValidator();
+}


### PR DESCRIPTION
--- 0.3.0 ---
[New]
OneDriveFile now implements ICreatedAtOffset, ILastAccessedAtOffset, and ILastModifiedAtOffset.
OneDriveFolder now implements ICreatedAtOffset, ILastAccessedAtOffset, and ILastModifiedAtOffset.
Added OneDriveCreatedAtProperty, OneDriveCreatedAtOffsetProperty, OneDriveLastAccessedAtProperty, OneDriveLastAccessedAtOffsetProperty, OneDriveLastModifiedAtProperty, OneDriveLastModifiedAtOffsetProperty - each backed by Microsoft Graph DriveItem timestamp fields.

[Dependencies]
Updated OwlCore.Storage to 0.15.0.
Updated Microsoft.Graph to 5.103.0.
Updated Microsoft.SourceLink.GitHub to 10.0.103.
Updated System.Linq.Async to 7.0.0.
Updated Microsoft.Bcl.AsyncInterfaces to 10.0.3.
Added net9.0 and net10.0 target frameworks.